### PR TITLE
[PR] Filter default content syndicate output

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -4,6 +4,7 @@ include_once __DIR__ . '/includes/university-center-objects.php';
 include_once __DIR__ . '/includes/sub-headline.php';
 include_once __DIR__ . '/includes/feature-video.php';
 include_once __DIR__ . '/includes/people-directory.php';
+include_once __DIR__ . '/includes/content-syndicate.php';
 
 add_filter( 'spine_child_theme_version', 'murrow_theme_version' );
 function murrow_theme_version() {

--- a/includes/content-syndicate.php
+++ b/includes/content-syndicate.php
@@ -104,7 +104,7 @@ function wsuwp_json_output( $content, $data, $atts ) {
 						<?php
 
 						// If a caption is not manually assigned, then WordPress will auto-create a caption that we should not use.
-						if ( false === strpos( $content->featured_media->caption->rendered, $content->featured_media->source_url ) ) :?>
+						if ( false === strpos( $content->featured_media->caption->rendered, $content->featured_media->source_url ) ) : ?>
 						<figcaption class="caption" itemprop="description">
 							<span class="caption-text"><?php echo wp_kses_post( $content->featured_media->caption->rendered ); ?></span>
 							<?php

--- a/includes/content-syndicate.php
+++ b/includes/content-syndicate.php
@@ -17,13 +17,16 @@ function wsuwp_json_output( $content, $data, $atts ) {
 					$offset_x++;
 					continue;
 				}
-				// @todo Check for data before outputting it.
+
 				?>
 				<article class="content-syndicate-item">
 					<?php if ( ! empty( $content->thumbnail ) ) : ?>
 					<figure class="content-item-image">
 						<a href="<?php echo esc_url( $content->link ); ?>"><img src="<?php echo esc_url( $content->thumbnail ); ?>" alt="<?php echo esc_attr( $content->featured_media->alt_text ); ?>"></a>
-						<?php if ( false === strpos( $content->featured_media->caption->rendered, $content->featured_media->source_url ) ) : ?>
+						<?php
+
+						// If a caption is not manually assigned, then WordPress will auto-create a caption that we should not use.
+						if ( false === strpos( $content->featured_media->caption->rendered, $content->featured_media->source_url ) ) :?>
 						<figcaption class="caption" itemprop="description">
 							<span class="caption-text"><?php echo wp_kses_post( $content->featured_media->caption->rendered ); ?></span>
 							<span class="credit" itemprop="copyrightHolder">

--- a/includes/content-syndicate.php
+++ b/includes/content-syndicate.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace WSU\Murrow\Content_Syndicate;
+
+add_filter( 'wsuwp_content_syndicate_json_output', 'WSU\Murrow\Content_Syndicate\wsuwp_json_output', 10, 3 );
+
+function wsuwp_json_output( $content, $data, $atts ) {
+	// Provide a default output for when no `output` attribute is included.
+	if ( 'json' === $atts['output'] ) {
+		ob_start();
+		?>
+		<div class="content-syndicate-wrapper">
+			<?php
+			$offset_x = 0;
+			foreach ( $data as $content ) {
+				if ( $offset_x < absint( $atts['offset'] ) ) {
+					$offset_x++;
+					continue;
+				}
+
+				// @todo Check for data before outputting it.
+				?>
+				<article class="content-syndicate-item">
+					<figure class="content-item-image">
+						<a href="<?php echo esc_url( $content->link ); ?>"><img src="<?php echo esc_url( $content->thumbnail ); ?>" alt="<?php echo esc_attr( $content->featured_media->alt_text ); ?>"></a>
+						<figcaption class="caption" itemprop="description">
+							<span class="caption-text"><?php echo wp_kses_post( $content->featured_media->caption->rendered ); ?></span>
+							<span class="credit" itemprop="copyrightHolder">
+                            <?php // @todo <span class="visually-hidden">Credit</span> Bob Hubner, WSU Photo Services ?>
+                        </span>
+						</figcaption>
+					</figure>
+					<header class="content-item-title"><?php echo esc_html( $content->title ); ?></header>
+					<span class="content-item-byline">
+						<span class="content-item-byline-date"><?php echo esc_html( date( $atts['date_format'], strtotime( $content->date ) ) ); ?></span>
+						<span class="content-item-byline-author"><?php echo esc_html( $content->author_name ); ?></span>
+					</span>
+					<span class="content-item-excerpt">
+						<?php echo wp_kses_post( $content->sub_headline ); ?>
+					</span>
+					<span class="content-item-cta">
+						<a href="<?php echo esc_url( $content->link ); ?>">Read more</a>
+					</span>
+					<span class="content-item-categories">
+						<?php // @todo <a href="#">category</a>, <a href="#">research</a> ?>
+					</span>
+				</article>
+				<?php
+			}
+			?>
+		</div>
+		<?php
+		$content = ob_get_contents();
+		ob_end_clean();
+	}
+
+	return $content;
+}

--- a/includes/content-syndicate.php
+++ b/includes/content-syndicate.php
@@ -17,19 +17,22 @@ function wsuwp_json_output( $content, $data, $atts ) {
 					$offset_x++;
 					continue;
 				}
-
 				// @todo Check for data before outputting it.
 				?>
 				<article class="content-syndicate-item">
+					<?php if ( ! empty( $content->thumbnail ) ) : ?>
 					<figure class="content-item-image">
 						<a href="<?php echo esc_url( $content->link ); ?>"><img src="<?php echo esc_url( $content->thumbnail ); ?>" alt="<?php echo esc_attr( $content->featured_media->alt_text ); ?>"></a>
+						<?php if ( false === strpos( $content->featured_media->caption->rendered, $content->featured_media->source_url ) ) : ?>
 						<figcaption class="caption" itemprop="description">
 							<span class="caption-text"><?php echo wp_kses_post( $content->featured_media->caption->rendered ); ?></span>
 							<span class="credit" itemprop="copyrightHolder">
 								<?php // @todo <span class="visually-hidden">Credit</span> Bob Hubner, WSU Photo Services ?>
 							</span>
 						</figcaption>
+						<?php endif; ?>
 					</figure>
+					<?php endif; ?>
 					<header class="content-item-title"><?php echo esc_html( $content->title ); ?></header>
 					<span class="content-item-byline">
 						<span class="content-item-byline-date"><?php echo esc_html( date( $atts['date_format'], strtotime( $content->date ) ) ); ?></span>

--- a/includes/content-syndicate.php
+++ b/includes/content-syndicate.php
@@ -26,8 +26,8 @@ function wsuwp_json_output( $content, $data, $atts ) {
 						<figcaption class="caption" itemprop="description">
 							<span class="caption-text"><?php echo wp_kses_post( $content->featured_media->caption->rendered ); ?></span>
 							<span class="credit" itemprop="copyrightHolder">
-                            <?php // @todo <span class="visually-hidden">Credit</span> Bob Hubner, WSU Photo Services ?>
-                        </span>
+								<?php // @todo <span class="visually-hidden">Credit</span> Bob Hubner, WSU Photo Services ?>
+							</span>
 						</figcaption>
 					</figure>
 					<header class="content-item-title"><?php echo esc_html( $content->title ); ?></header>

--- a/includes/content-syndicate.php
+++ b/includes/content-syndicate.php
@@ -29,9 +29,11 @@ function wsuwp_json_output( $content, $data, $atts ) {
 						if ( false === strpos( $content->featured_media->caption->rendered, $content->featured_media->source_url ) ) :?>
 						<figcaption class="caption" itemprop="description">
 							<span class="caption-text"><?php echo wp_kses_post( $content->featured_media->caption->rendered ); ?></span>
-							<span class="credit" itemprop="copyrightHolder">
-								<?php // @todo <span class="visually-hidden">Credit</span> Bob Hubner, WSU Photo Services ?>
-							</span>
+							<?php
+							//<span class="credit" itemprop="copyrightHolder">
+							// @todo <span class="visually-hidden">Credit</span> Bob Hubner, WSU Photo Services
+							// </span>
+							?>
 						</figcaption>
 						<?php endif; ?>
 					</figure>


### PR DESCRIPTION
Implement content syndicate output for murrow.

* [x] Initial layout
* [x] Adjust content syndicate to provide more featured media data. See https://github.com/washingtonstateuniversity/WSUWP-Content-Syndicate/pull/87
* [x] Fix research.wsu.edu to work with content syndicate updates. See https://github.com/washingtonstateuniversity/research.wsu.edu/pull/38
* [x] Ship new content syndicate and research.wsu.edu versions to production.
* [x] Add categories support
* [x] Avoid errors when content is missing
* [x] Determine path forward for photo credits. See https://github.com/washingtonstateuniversity/murrow.wsu.edu/issues/35

Fixes #30.