### PR TITLE
Adjustments to featured-image pages, global bar

### DIFF
--- a/css/01-layout.css
+++ b/css/01-layout.css
@@ -58,9 +58,9 @@ main .breadcrumbs span {
 /* main header */
 .main-header {
 	background: none;
-	height: auto;
-	padding: 0 2rem;
-	margin: 6rem 0 0;
+	margin-top: 0;
+	margin-bottom: 0;
+	padding: 0;
 }
 
 /* populate red tab */
@@ -96,4 +96,40 @@ main .page > section,
 	max-width: 1188px;
 	margin-left: auto;
 	margin-right: auto;
+}
+
+/* --- secondary pages with featured image --- */
+.hentry {
+	display: grid;
+	grid-template-columns: 1fr minmax(auto, 594px) minmax(auto, 594px) 1fr;
+}
+
+.hentry section {
+	grid-column: 2 / 4;
+}
+
+.has-featured-image .hentry .featured-image-wrapper + section {
+	grid-column: 2 / 3;
+	grid-row-start: 1;
+	background: none;
+	margin-top: 0;
+}
+
+.has-featured-image .hentry .featured-image-wrapper + section .column.one {
+	width: 100%;
+}
+
+.has-featured-image .hentry .featured-image-wrapper + section .column.two {
+	display: none;
+}
+
+.featured-image-wrapper {
+	grid-column: 3 / 4;
+	margin-top: 6rem;
+	padding: 0 2rem;
+}
+
+.featured-image {
+	height: 0;
+	padding-bottom: 60%;
 }

--- a/css/02-typography.css
+++ b/css/02-typography.css
@@ -16,13 +16,20 @@ h6 {
 	padding: .5em 0 .2em;
 }
 
-.page h1 {
+h1 {
 	color: #a60f2d;
 	font-size: 3.5em;
 	line-height: 1em;
 	text-transform: uppercase;
 	font-weight: 300;
-	margin: 0;
+	margin: 5rem 0 2rem;
+}
+
+@media (min-width: 989px) {
+
+	.side-right header h1 {
+		width: 67%;
+	}
 }
 
 p,

--- a/css/03-header.css
+++ b/css/03-header.css
@@ -81,26 +81,25 @@
 	}
 
 	.global-bar-wrap {
-		background: rgba(0, 0, 0, .05);
-		border-bottom: 1px solid rgba(0, 0, 0, .1);
+		background: linear-gradient(to right, #a60f2d 7%, #ca1237 27%, #ca1237 41%, #a60f2d 75%);
 	}
 
 	.global-bar {
 		max-width: 1186px;
 		margin: 0 auto;
 		text-align: right;
-		padding: .5em 0;
 	}
 
 	#jacket .global-bar a.global-home {
-		color: #981e32;
+		color: #fff;
 		text-transform: uppercase;
 		font-size: 11px;
 		letter-spacing: .5px;
+		transition: color .3s ease;
 	}
 
 	#jacket .global-bar a.global-home:hover {
-		color: #b7203d;
+		color: #cecece;
 	}
 
 	.site-search {

--- a/css/04-content-cards.css
+++ b/css/04-content-cards.css
@@ -1,7 +1,8 @@
 .content-syndicate-wrapper {
 	display: grid;
-	grid-column-gap: 2rem;
+	grid-column-gap: 0;
 	grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+	margin: 0 -1rem;
 }
 
 /* - allow aligning elements within an item - */
@@ -9,6 +10,12 @@
 	display: flex;
 	flex-direction: column;
 	align-content: flex-start;
+	padding: 1rem;
+	transition: background-color .3s ease;
+}
+
+.content-syndicate-item:hover {
+	background-color: rgba(0, 0, 0, .035);
 }
 
 /* - allow for different size images to discplay uniformally - */
@@ -56,7 +63,8 @@
 }
 
 .content-item-categories a {
-	color: #404040;
+	color: rgba(0, 0, 0, .7);
+	font-size: .7rem;
 }
 
 .content-item-categories a:hover {

--- a/style-guide/general-elements.html
+++ b/style-guide/general-elements.html
@@ -124,13 +124,10 @@
 		<div class="column one">
 			<span property="itemListElement" typeof="ListItem"><a property="item" typeof="WebPage" title="Go to Murrow College of Communication." href="http://stage.murrow.wsu.edu" class="home"><span property="name">Murrow College of Communication</span></a><meta property="position" content="1"></span> / <span property="itemListElement" typeof="ListItem"><a property="item" typeof="WebPage" title="Go to Student Work." href="http://stage.murrow.wsu.edu/student-work/" class="post post-page"><span property="name">Student Work</span></a><meta property="position" content="2"></span> / <span property="itemListElement" typeof="ListItem"><span property="name">Backpack Journalism &amp; Global Expeditions</span><meta property="position" content="3"></span>		</div>
 	</section>
-	<section class="main-header">
-		<h1>Undergraduate programs</h1>
-	</section>
 	<div id="page-182" class="post-182 page type-page status-publish hentry category-uncategorized wsuwp_university_org-edward-r-murrow-college-of-communication">
 		<section id="builder-section-1496264228343" class="row side-right gutter pad-top">
 					<div style="" class="column one ">
-
+								<h1>Undergraduate education</h1>
 
 								<p>The Edward R. Murrow College of Communication is committed to a skills-based, hands-on undergraduate curriculum that prepares students for professional success. This is consistent with Washington State University’s pursuit of a transformative educational experience for its students. This commitment is reflected in applied coursework, internship opportunities, student mentoring by professionals, an emphasis on international learning opportunities, and our dedicated student services programs.</p>
 

--- a/style-guide/secondary.html
+++ b/style-guide/secondary.html
@@ -1,0 +1,283 @@
+<!DOCTYPE html>
+<!--[if lt IE 7]> <html class="no-js no-svg lt-ie9 lt-ie8 lt-ie7" lang="en"> <![endif]-->
+<!--[if IE 7]><html class="no-js no-svg lt-ie9 lt-ie8" lang="en"> <![endif]-->
+<!--[if IE 8]><html class="no-js no-svg lt-ie9" lang="en"> <![endif]-->
+<!--[if gt IE 8]><!--><html class="no-js" lang="en-US"><!--<![endif]-->
+<head>
+	<meta http-equiv="X-UA-Compatible" content="IE=EDGE">
+	<meta charset="UTF-8" />
+	<title>Edward R. Murrow College of Communication | Washington State University</title>
+	<!-- FAVICON -->
+	<link rel="shortcut icon" href="https://repo.wsu.edu/spine/1/favicon.ico" />
+	<!-- RESPOND -->
+	<meta name="viewport" content="width=device-width, user-scalable=yes">
+	<!-- SCRIPTS and STYLES -->
+	<link rel="stylesheet" id="wsu-spine-css" href="https://repo.wsu.edu/spine/1/spine.min.css?ver=0.27.10-1.6.4-40891" type="text/css" media="all" />
+	<link rel="stylesheet" id="spine-theme-css" href="https://web.wsu.edu/wp-content/themes/spine/style.css?ver=0.27.10-1.6.4-40891" type="text/css" media="all" />
+	<link rel="stylesheet" id="spine-theme-child-css" href="../style.css" type="text/css" media="all" />
+	<link rel="stylesheet" id="spine-theme-print-css" href="https://web.wsu.edu/wp-content/themes/spine/css/print.css?ver=0.27.10-1.6.4-40891" type="text/css" media="print" />
+	<link rel="stylesheet" id="open-sans-css" href="//fonts.googleapis.com/css?family=Open+Sans%3A300%2C300italic%2C600%2C800%2C400%2C400italic%2C700%2C700italic&#038;subset=latin%2Clatin-ext&#038;ver=4.8" type="text/css" media="all" />
+	<script type="text/javascript" src="https://web.wsu.edu/wp-includes/js/jquery/jquery.js?ver=1.12.4"></script>
+	<script type="text/javascript" src="https://web.wsu.edu/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1"></script>
+	<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js?ver=4.8"></script>
+	<script type="text/javascript" src="../js/spine.min.js"></script>
+	<style type="text/css">
+		.recentcomments a {
+			display: inline !important;
+			padding: 0 !important;
+			margin: 0 !important;
+		}
+	</style>
+	<!-- COMPATIBILITY -->
+	<!--[if lt IE 9]><script src="https://html5shiv.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
+	<noscript>
+		<style>
+			#spine #spine-sitenav ul ul li {
+				display: block !important;
+			}
+		</style>
+	</noscript>
+</head>
+
+<body class="has-featured-image page-template page-template-template-builder page-template-template-builder-php page opensansy single depth-0">
+	<a href="#wsuwp-main" class="screen-reader-shortcut">Skip to main content</a>
+	<a href="#spine-sitenav" class="screen-reader-shortcut">Skip to navigation</a>
+	<div id="jacket" class="style-skeletal colors-default spacing-default">
+		<div id="binder" class="fluid folio max-1188">
+			<div class="global-bar-wrap">
+				<div class="global-bar">
+					<a class="global-home" href="https://wsu.edu">Washington State University</a>
+				</div>
+			</div>
+			<div id="contact-search" class="site-search">
+				<ul>
+					<li class="menu-item menu-item-type-post_type menu-item-object-page"><a href="#">Contact</a></li>
+					<li class="search">
+						<form role="search" method="get" class="search-form" action="">
+							<label>
+								<span class="screen-reader-text">Search for:</span>
+								<input type="search" class="search-field" placeholder="Search &hellip;" value="" name="s" />
+							</label>
+							<input type="submit" class="search-submit" value="Search" />
+						</form>
+					</li>
+				</ul>
+			</div>
+
+			<div id="spine" class="spine-column darker search-closed shelved">
+				<div id="glue" class="spine-glue">
+					<header class="spine-header">
+						<a href="https://murrow.wsu.edu" id="wsu-signature">Edward R. Murrow College of Communication</a>
+					</header>
+					<section id="wsu-actions" class="spine-actions clearfix">
+						<ul id="wsu-actions-tabs" class="spine-actions-tabs spine-tabs clearfix">
+							<li id="wsu-search-tab" class="spine-search-tab closed"><button>Search</button></li>
+							<li id="wsu-contact-tab" class="spine-contact-tab closed"><button>Contact</button></li>
+							<li id="wsu-share-tab" class="spine-share-tab closed"><button>Share</button></li>
+						</ul>
+					</section><!--/#wsu-actions-->
+					<section id="spine-navigation" class="spine-navigation">
+						<nav id="spine-sitenav" class="spine-sitenav">
+							<ul>
+								<li class="active"><a href="#">Communications Home</a></li>
+								<li><a href="#">About</a>
+									<ul class="sub-menu">
+										<li><a href="#">Dean&#8217;s Message</a></li>
+										<li><a href="#">Mission Statement</a></li>
+									</ul>
+								</li>
+								<li><a href="#">Academics</a>
+									<ul class="sub-menu">
+										<li><a href="#">Undergraduate Studies</a></li>
+										<li><a href="#">Graduate Studies</a></li>
+									</ul>
+								</li>
+								<li><a href="#">News</a></li>
+							</ul>
+						</nav>
+						<nav id="spine-offsitenav" class="spine-offsitenav"></nav>
+					</section>
+					<footer class="spine-footer">
+						<nav id="wsu-social-channels" class="spine-social-channels">
+							<ul>
+								<li class="facebook-channel"><a href="https://www.facebook.com/WSUPullman">facebook</a></li>
+								<li class="twitter-channel"><a href="https://twitter.com/wsupullman">twitter</a></li>
+								<li class="youtube-channel"><a href="https://www.youtube.com/washingtonstateuniv">youtube</a></li>
+								<li class="directory-channel"><a href="http://social.wsu.edu">directory</a></li>
+							</ul>
+						</nav>
+						<nav id="wsu-global-links" class="spine-global-links">
+							<ul>
+								<li class="mywsu-link"><a href="https://portal.wsu.edu/">myWSU</a></li>
+								<li class="access-link"><a href="https://access.wsu.edu/">Access</a></li>
+								<li class="policies-link"><a href="https://policies.wsu.edu/">Policies</a></li>
+								<li class="copyright-link"><a href="https://copyright.wsu.edu">&copy;</a></li>
+							</ul>
+						</nav>
+					</footer>
+				</div><!--/glue-->
+			</div><!--/spine-->
+
+			<main id="wsuwp-main" class="spine-blank-template">
+				<section class="row single breadcrumbs breadcrumbs-top gutter pad-top" typeof="BreadcrumbList" vocab="http://schema.org/">
+		<div class="column one">
+			<span property="itemListElement" typeof="ListItem"><a property="item" typeof="WebPage" title="Go to Murrow College of Communication." href="http://stage.murrow.wsu.edu" class="home"><span property="name">Murrow College of Communication</span></a><meta property="position" content="1"></span> / <span property="itemListElement" typeof="ListItem"><a property="item" typeof="WebPage" title="Go to Student Work." href="http://stage.murrow.wsu.edu/student-work/" class="post post-page"><span property="name">Student Work</span></a><meta property="position" content="2"></span> / <span property="itemListElement" typeof="ListItem"><span property="name">Backpack Journalism &amp; Global Expeditions</span><meta property="position" content="3"></span>		</div>
+	</section>
+  <div id="page-197" class="post-197 page type-page status-publish has-post-thumbnail hentry category-student-work wsuwp_university_org-edward-r-murrow-college-of-communication">
+    <div class="featured-image-wrapper">
+    <figure class="featured-image " style="background-image: url('https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-1188x430.jpg');"><img width="792" height="287" src="https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-792x287.jpg" class="attachment-spine-medium_size size-spine-medium_size wp-post-image" alt="" srcset="https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-792x287.jpg 792w, https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-396x143.jpg 396w, https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-768x278.jpg 768w, https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-990x358.jpg 990w, https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-1188x430.jpg 1188w" sizes="(max-width: 792px) 100vw, 792px"></figure>
+  </div>
+  				<section id="builder-section-1496265321861" class="row side-right gutter">
+  						<header>
+  					<h1>Beyond the Classroom</h1>
+  				</header>
+  								<div style="" class="column one ">
+
+
+
+  <p>True to our legacy, the Edward R. Murrow College of Communication is dedicated to providing students—the communications professionals of the future—this same level of inspiration, experience, and real-world education.</p>
+
+  				</div>
+  							<div style="" class="column two ">
+
+
+
+  				</div>
+  				</section>
+  <section id="builder-section-1501353388815" class="row side-right gutter pad-top">
+  								<div style="" class="column one ">
+
+  																	<header>
+  							<h2>Student Stories</h2>
+  						</header>
+
+  											<p>Murrow students are storytellers who engage in collaborative learning experiences that span the globe, from the rolling hills of the Palouse to the mountains of Nepal.</p>
+  <h4>Recent stories</h4>
+  <p>&lt;!–would be great if we could display the three most recent posts with the category “Student Stories” here&gt;</p>
+  <p>Explore more&nbsp;<a href="https://stage.murrow.wsu.edu/student-work/student-stories/"><strong>student stories</strong></a></p>
+
+  				</div>
+  							<div style="" class="column two ">
+
+
+
+  				</div>
+  				</section>
+  	<section id="builder-section-1501352786146" class="row side-right gutter pad-top">
+  								<div style="" class="column one ">
+
+  																	<header>
+  							<h2>Student Media</h2>
+  						</header>
+
+  											<h3 class="p1">Murrow News 8</h3>
+  <p class="p2"><span class="s1">Murrow News 8 is a nightly newscast produced, written, anchored and crewed entirely by students from the Edward R. Murrow College of Communication.</span></p>
+  <p><a href="https://stage.murrow.wsu.edu/student-work/murrow-news-8/">Learn more about Murrow News 8</a></p>
+  <h3 class="p2"><span class="s1">Murrow News Service</span></h3>
+  <p class="p2"><span class="s1">The Murrow News Service was created to provide students with experience in creating professional news stories, as well as to provide information to the public and media outlets. NWPR and NWPTV are trusted sources of quality content; students working within these properties get hands-on experience writing, editing, and producing content for a professional, statewide public radio and television service.</span></p>
+  <p><a href="https://stage.murrow.wsu.edu/student-work/murrow-news-service/">Learn more about Murrow News Service</a></p>
+  <h3 class="p1"></h3>
+  <h4 class="p1"></h4>
+
+  				</div>
+  							<div style="" class="column two ">
+
+
+
+  				</div>
+  				</section>
+  	<section id="builder-section-1501352494836" class="row side-right gutter pad-top">
+  								<div style="" class="column one ">
+
+  																	<header>
+  							<h2>Global Learning Experiences</h2>
+  						</header>
+
+  											<h3 class="p1">Backpack Journalism</h3>
+  <p class="p2"><span class="s1">The Murrow Backpack Journalism program provides a unique opportunity for the most accomplished students in the college to travel abroad and work in an international environment. Backpack Journalism students experience the challenges and benefits of international travel, may have their work published by professional media and enrich their academic and professional lives.</span></p>
+  <p><a href="https://stage.murrow.wsu.edu/student-work/backpack-journalism-global-expeditions/">Learn more about Backpack Journalism</a></p>
+  <h3 class="p1">Backpack Environmental</h3>
+  <p class="p2"><span class="s1">Murrow students who love nature, the Earth, and need to be the first to know about groundbreaking environmental science can be a part of the Backpack Environmental program. Student journalists travel around the country and work side-by-side with environmental scientists conducting cutting-edge experiments, and have the opportunity to profile their work.</span></p>
+  <p><a href="https://stage.murrow.wsu.edu/student-work/backpack-journalism-global-expeditions/">Learn more about Backpack Environmental</a></p>
+  <h3 class="p1">Study Abroad: Murrow Global Expeditions</h3>
+  <p class="p2"><span class="s1">The mission in May 2017: for students to find their own stories while immersed in two incredible international locations. “Havana, Pearl of the Caribbean,” will mark our fourth Global Expedition to this cultural treasure, now open to U.S. Citizens after decades of political and social isolation. A new program, “Epic Stories of Greece,” offers an unforgettable one-month learning experience in Thessaloniki, Greece.</span></p>
+  <p><a href="https://stage.murrow.wsu.edu/student-work/backpack-journalism-global-expeditions/">Learn more about Global Expeditions</a></p>
+  <h3 class="p1"></h3>
+
+  				</div>
+  							<div style="" class="column two ">
+
+
+
+  				</div>
+  				</section>
+  	<section id="builder-section-1496876373135" class="row side-right gutter pad-top">
+  								<div style="" class="column one ">
+
+  																	<header>
+  							<h2>Internships</h2>
+  						</header>
+
+  											<p class="p2"><span class="s1">We have established relationships with major media companies, public relations, and advertising agencies. Dedicated Career Services staff keeps students connected to internship and job opportunities, and our strong corporate partners like Boeing and the Seahawks, students with professional networking and resume building connections. </span></p>
+
+  				</div>
+  							<div style="" class="column two ">
+
+
+
+  				</div>
+  				</section>
+  	<section id="builder-section-1501354050278" class="row side-right gutter pad-top">
+  								<div style="" class="column one ">
+
+  																	<header>
+  							<h2>Student Clubs and Organizations</h2>
+  						</header>
+
+  											<p>Need a description here</p>
+  <p>Find a <a href="https://stage.murrow.wsu.edu/student-work/student-clubs-organizations/"><strong>student club or organization</strong></a> that matches your interests</p>
+
+  				</div>
+  							<div style="" class="column two ">
+
+
+
+  				</div>
+  				</section>
+  	<section id="builder-section-1501353119665" class="row side-right gutter pad-top">
+  								<div style="" class="column one ">
+
+  																	<header>
+  							<h2>Awards and Achievements</h2>
+  						</header>
+
+  											<p class="p2"><span class="s1">Murrow students are regularly featured and granted awards by the American Advertising Federation, PRSSA’s Bateman Case Study Competition, the Society of Professional Journalism, the National Academy of Television Arts and Sciences, and the National Student Advertising Competition. Each of these organizations provides professional networking, career development and real-world experiences that put our students at an advantage in the workplace.</span></p>
+  <p>See our recent student and faculty awards (need a link to posts tagged as “Awards”)</p>
+
+  				</div>
+  							<div style="" class="column two ">
+
+
+
+  				</div>
+  				</section>
+  			</div>
+</main>
+
+</div><!--/binder-->
+</div><!--/jacket-->
+<div id="contact-details" itemscope itemtype="http://schema.org/Organization">
+<meta itemprop="name" class="required" content="Washington State University">
+<meta itemprop="department" class="required" content="">
+<div itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+<meta itemprop="streetAddress" class="optional" content="PO Box 641227">
+<meta itemprop="addressLocality" class="optional" content="Pullman, WA">
+<meta itemprop="postalCode" class="required" content="99164">
+</div>
+<meta itemprop="telephone" class="required" content="(509) 335-3564">
+<meta itemprop="email" class="required" content="info@wsu.edu">
+</div>
+<script type='text/javascript' src='https://web.wsu.edu/wp-content/themes/spine/js/spine-theme.js?ver=0.27.10-1.6.4-40891'></script>
+<script type='text/javascript' src='https://web.wsu.edu/wp-includes/js/wp-embed.min.js?ver=4.8'></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -68,9 +68,9 @@ main .breadcrumbs span {
 /* main header */
 .main-header {
 	background: none;
-	height: auto;
-	padding: 0 2rem;
-	margin: 6rem 0 0;
+	margin-top: 0;
+	margin-bottom: 0;
+	padding: 0;
 }
 
 /* populate red tab */
@@ -108,6 +108,42 @@ main .page > section,
 	margin-right: auto;
 }
 
+/* --- secondary pages with featured image --- */
+.hentry {
+	display: grid;
+	grid-template-columns: 1fr minmax(auto, 594px) minmax(auto, 594px) 1fr;
+}
+
+.hentry section {
+	grid-column: 2 / 4;
+}
+
+.has-featured-image .hentry .featured-image-wrapper + section {
+	grid-column: 2 / 3;
+	grid-row-start: 1;
+	background: none;
+	margin-top: 0;
+}
+
+.has-featured-image .hentry .featured-image-wrapper + section .column.one {
+	width: 100%;
+}
+
+.has-featured-image .hentry .featured-image-wrapper + section .column.two {
+	display: none;
+}
+
+.featured-image-wrapper {
+	grid-column: 3 / 4;
+	margin-top: 6rem;
+	padding: 0 2rem;
+}
+
+.featured-image {
+	height: 0;
+	padding-bottom: 60%;
+}
+
 body {
 	color: #424242;
 	font-weight: 300;
@@ -126,13 +162,20 @@ h6 {
 	padding: .5em 0 .2em;
 }
 
-.page h1 {
+h1 {
 	color: #a60f2d;
 	font-size: 3.5em;
 	line-height: 1em;
 	text-transform: uppercase;
 	font-weight: 300;
-	margin: 0;
+	margin: 5rem 0 2rem;
+}
+
+@media (min-width: 989px) {
+
+	.side-right header h1 {
+		width: 67%;
+	}
 }
 
 p,
@@ -342,26 +385,25 @@ main a::selection {
 	}
 
 	.global-bar-wrap {
-		background: rgba(0, 0, 0, .05);
-		border-bottom: 1px solid rgba(0, 0, 0, .1);
+		background: linear-gradient(to right, #a60f2d 7%, #ca1237 27%, #ca1237 41%, #a60f2d 75%);
 	}
 
 	.global-bar {
 		max-width: 1186px;
 		margin: 0 auto;
 		text-align: right;
-		padding: .5em 0;
 	}
 
 	#jacket .global-bar a.global-home {
-		color: #981e32;
+		color: #fff;
 		text-transform: uppercase;
 		font-size: 11px;
 		letter-spacing: .5px;
+		transition: color .3s ease;
 	}
 
 	#jacket .global-bar a.global-home:hover {
-		color: #b7203d;
+		color: #cecece;
 	}
 
 	.site-search {
@@ -852,8 +894,9 @@ main a::selection {
 
 .content-syndicate-wrapper {
 	display: grid;
-	grid-column-gap: 2rem;
+	grid-column-gap: 0;
 	grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+	margin: 0 -1rem;
 }
 
 /* - allow aligning elements within an item - */
@@ -867,6 +910,12 @@ main a::selection {
 	        flex-direction: column;
 	-ms-flex-line-pack: start;
 	    align-content: flex-start;
+	padding: 1rem;
+	transition: background-color .3s ease;
+}
+
+.content-syndicate-item:hover {
+	background-color: rgba(0, 0, 0, .035);
 }
 
 /* - allow for different size images to discplay uniformally - */
@@ -916,7 +965,8 @@ main a::selection {
 }
 
 .content-item-categories a {
-	color: #404040;
+	color: rgba(0, 0, 0, .7);
+	font-size: .7rem;
 }
 
 .content-item-categories a:hover {


### PR DESCRIPTION
Introduced CSS Grid to `has-featured-image` pages.
-- fallback coming

Changed `global-bar` to `crimson`.

Changed location of `featured-image` in HTML to appear below `.hentry` and introduced a wrapper.
```
<div class="featured-image-wrapper">
    <figure class="featured-image " style="background-image: url('https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-1188x430.jpg');"><img... 
```