### PR TITLE
[PR] Adjust HTML for featured image output on pages

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -15,6 +15,10 @@ function murrow_theme_version() {
 add_filter( 'spine_post_supports_background_image', '__return_false' );
 add_filter( 'spine_page_supports_background_image', '__return_false' );
 
+// Disable thumbnail image selection for posts and pages.
+add_filter( 'spine_post_supports_thumbnail_image', '__return_false' );
+add_filter( 'spine_page_supports_thumbnail_image', '__return_false' );
+
 add_action( 'init', 'murrow_remove_spine_wp_enqueue_scripts' );
 function murrow_remove_spine_wp_enqueue_scripts() {
 	remove_action( 'wp_enqueue_scripts', 'spine_wp_enqueue_scripts', 20 );

--- a/style-guide/secondary.html
+++ b/style-guide/secondary.html
@@ -129,8 +129,8 @@
 
 			<div id="page-197" class="post-197 page type-page status-publish has-post-thumbnail hentry category-student-work wsuwp_university_org-edward-r-murrow-college-of-communication">
 				<div class="featured-image-wrapper">
-					<figure class="featured-image " style="background-image: url('https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-1188x430.jpg');">
-						<img width="792" height="287" src="https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-792x287.jpg" class="attachment-spine-medium_size size-spine-medium_size wp-post-image" alt="" srcset="https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-792x287.jpg 792w, https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-396x143.jpg 396w, https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-768x278.jpg 768w, https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-990x358.jpg 990w, https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-1188x430.jpg 1188w" sizes="(max-width: 792px) 100vw, 792px">
+					<figure class="featured-image " style="background-image: url('https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/08/IMG_1128.jpg');">
+						<img width="792" height="287" src="https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/08/IMG_1128.jpg" class="attachment-spine-medium_size size-spine-medium_size wp-post-image" alt="">
 					</figure>
 				</div>
 

--- a/style-guide/secondary.html
+++ b/style-guide/secondary.html
@@ -40,232 +40,216 @@
 </head>
 
 <body class="has-featured-image page-template page-template-template-builder page-template-template-builder-php page opensansy single depth-0">
-	<a href="#wsuwp-main" class="screen-reader-shortcut">Skip to main content</a>
-	<a href="#spine-sitenav" class="screen-reader-shortcut">Skip to navigation</a>
-	<div id="jacket" class="style-skeletal colors-default spacing-default">
-		<div id="binder" class="fluid folio max-1188">
-			<div class="global-bar-wrap">
-				<div class="global-bar">
-					<a class="global-home" href="https://wsu.edu">Washington State University</a>
-				</div>
-			</div>
-			<div id="contact-search" class="site-search">
-				<ul>
-					<li class="menu-item menu-item-type-post_type menu-item-object-page"><a href="#">Contact</a></li>
-					<li class="search">
-						<form role="search" method="get" class="search-form" action="">
-							<label>
-								<span class="screen-reader-text">Search for:</span>
-								<input type="search" class="search-field" placeholder="Search &hellip;" value="" name="s" />
-							</label>
-							<input type="submit" class="search-submit" value="Search" />
-						</form>
-					</li>
-				</ul>
-			</div>
+<a href="#wsuwp-main" class="screen-reader-shortcut">Skip to main content</a>
+<a href="#spine-sitenav" class="screen-reader-shortcut">Skip to navigation</a>
+<div id="jacket" class="style-skeletal colors-default spacing-default">
+	<div id="binder" class="fluid folio max-1188">
 
-			<div id="spine" class="spine-column darker search-closed shelved">
-				<div id="glue" class="spine-glue">
-					<header class="spine-header">
-						<a href="https://murrow.wsu.edu" id="wsu-signature">Edward R. Murrow College of Communication</a>
-					</header>
-					<section id="wsu-actions" class="spine-actions clearfix">
-						<ul id="wsu-actions-tabs" class="spine-actions-tabs spine-tabs clearfix">
-							<li id="wsu-search-tab" class="spine-search-tab closed"><button>Search</button></li>
-							<li id="wsu-contact-tab" class="spine-contact-tab closed"><button>Contact</button></li>
-							<li id="wsu-share-tab" class="spine-share-tab closed"><button>Share</button></li>
+		<div class="global-bar-wrap">
+			<div class="global-bar">
+				<a class="global-home" href="https://wsu.edu">Washington State University</a>
+			</div>
+		</div>
+
+		<div id="contact-search" class="site-search">
+			<ul>
+				<li class="menu-item menu-item-type-post_type menu-item-object-page"><a href="#">Contact</a></li>
+				<li class="search">
+					<form role="search" method="get" class="search-form" action="">
+						<label>
+							<span class="screen-reader-text">Search for:</span>
+							<input type="search" class="search-field" placeholder="Search &hellip;" value="" name="s" />
+						</label>
+						<input type="submit" class="search-submit" value="Search" />
+					</form>
+				</li>
+			</ul>
+		</div>
+
+		<div id="spine" class="spine-column darker search-closed shelved">
+			<div id="glue" class="spine-glue">
+				<header class="spine-header">
+					<a href="https://murrow.wsu.edu" id="wsu-signature">Edward R. Murrow College of Communication</a>
+				</header>
+				<section id="wsu-actions" class="spine-actions clearfix">
+					<ul id="wsu-actions-tabs" class="spine-actions-tabs spine-tabs clearfix">
+						<li id="wsu-search-tab" class="spine-search-tab closed"><button>Search</button></li>
+						<li id="wsu-contact-tab" class="spine-contact-tab closed"><button>Contact</button></li>
+						<li id="wsu-share-tab" class="spine-share-tab closed"><button>Share</button></li>
+					</ul>
+				</section><!--/#wsu-actions-->
+				<section id="spine-navigation" class="spine-navigation">
+					<nav id="spine-sitenav" class="spine-sitenav">
+						<ul>
+							<li class="active"><a href="#">Communications Home</a></li>
+							<li><a href="#">About</a>
+								<ul class="sub-menu">
+									<li><a href="#">Dean&#8217;s Message</a></li>
+									<li><a href="#">Mission Statement</a></li>
+								</ul>
+							</li>
+							<li><a href="#">Academics</a>
+								<ul class="sub-menu">
+									<li><a href="#">Undergraduate Studies</a></li>
+									<li><a href="#">Graduate Studies</a></li>
+								</ul>
+							</li>
+							<li><a href="#">News</a></li>
 						</ul>
-					</section><!--/#wsu-actions-->
-					<section id="spine-navigation" class="spine-navigation">
-						<nav id="spine-sitenav" class="spine-sitenav">
-							<ul>
-								<li class="active"><a href="#">Communications Home</a></li>
-								<li><a href="#">About</a>
-									<ul class="sub-menu">
-										<li><a href="#">Dean&#8217;s Message</a></li>
-										<li><a href="#">Mission Statement</a></li>
-									</ul>
-								</li>
-								<li><a href="#">Academics</a>
-									<ul class="sub-menu">
-										<li><a href="#">Undergraduate Studies</a></li>
-										<li><a href="#">Graduate Studies</a></li>
-									</ul>
-								</li>
-								<li><a href="#">News</a></li>
-							</ul>
-						</nav>
-						<nav id="spine-offsitenav" class="spine-offsitenav"></nav>
-					</section>
-					<footer class="spine-footer">
-						<nav id="wsu-social-channels" class="spine-social-channels">
-							<ul>
-								<li class="facebook-channel"><a href="https://www.facebook.com/WSUPullman">facebook</a></li>
-								<li class="twitter-channel"><a href="https://twitter.com/wsupullman">twitter</a></li>
-								<li class="youtube-channel"><a href="https://www.youtube.com/washingtonstateuniv">youtube</a></li>
-								<li class="directory-channel"><a href="http://social.wsu.edu">directory</a></li>
-							</ul>
-						</nav>
-						<nav id="wsu-global-links" class="spine-global-links">
-							<ul>
-								<li class="mywsu-link"><a href="https://portal.wsu.edu/">myWSU</a></li>
-								<li class="access-link"><a href="https://access.wsu.edu/">Access</a></li>
-								<li class="policies-link"><a href="https://policies.wsu.edu/">Policies</a></li>
-								<li class="copyright-link"><a href="https://copyright.wsu.edu">&copy;</a></li>
-							</ul>
-						</nav>
-					</footer>
-				</div><!--/glue-->
-			</div><!--/spine-->
+					</nav>
+					<nav id="spine-offsitenav" class="spine-offsitenav"></nav>
+				</section>
+				<footer class="spine-footer">
+					<nav id="wsu-social-channels" class="spine-social-channels">
+						<ul>
+							<li class="facebook-channel"><a href="https://www.facebook.com/WSUPullman">facebook</a></li>
+							<li class="twitter-channel"><a href="https://twitter.com/wsupullman">twitter</a></li>
+							<li class="youtube-channel"><a href="https://www.youtube.com/washingtonstateuniv">youtube</a></li>
+							<li class="directory-channel"><a href="http://social.wsu.edu">directory</a></li>
+						</ul>
+					</nav>
+					<nav id="wsu-global-links" class="spine-global-links">
+						<ul>
+							<li class="mywsu-link"><a href="https://portal.wsu.edu/">myWSU</a></li>
+							<li class="access-link"><a href="https://access.wsu.edu/">Access</a></li>
+							<li class="policies-link"><a href="https://policies.wsu.edu/">Policies</a></li>
+							<li class="copyright-link"><a href="https://copyright.wsu.edu">&copy;</a></li>
+						</ul>
+					</nav>
+				</footer>
+			</div><!--/glue-->
+		</div><!--/spine-->
 
-			<main id="wsuwp-main" class="spine-blank-template">
-				<section class="row single breadcrumbs breadcrumbs-top gutter pad-top" typeof="BreadcrumbList" vocab="http://schema.org/">
-		<div class="column one">
-			<span property="itemListElement" typeof="ListItem"><a property="item" typeof="WebPage" title="Go to Murrow College of Communication." href="http://stage.murrow.wsu.edu" class="home"><span property="name">Murrow College of Communication</span></a><meta property="position" content="1"></span> / <span property="itemListElement" typeof="ListItem"><a property="item" typeof="WebPage" title="Go to Student Work." href="http://stage.murrow.wsu.edu/student-work/" class="post post-page"><span property="name">Student Work</span></a><meta property="position" content="2"></span> / <span property="itemListElement" typeof="ListItem"><span property="name">Backpack Journalism &amp; Global Expeditions</span><meta property="position" content="3"></span>		</div>
-	</section>
-  <div id="page-197" class="post-197 page type-page status-publish has-post-thumbnail hentry category-student-work wsuwp_university_org-edward-r-murrow-college-of-communication">
-    <div class="featured-image-wrapper">
-    <figure class="featured-image " style="background-image: url('https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-1188x430.jpg');"><img width="792" height="287" src="https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-792x287.jpg" class="attachment-spine-medium_size size-spine-medium_size wp-post-image" alt="" srcset="https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-792x287.jpg 792w, https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-396x143.jpg 396w, https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-768x278.jpg 768w, https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-990x358.jpg 990w, https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-1188x430.jpg 1188w" sizes="(max-width: 792px) 100vw, 792px"></figure>
-  </div>
+		<main id="wsuwp-main" class="spine-blank-template">
+			<section class="row single breadcrumbs breadcrumbs-top gutter pad-top" typeof="BreadcrumbList" vocab="http://schema.org/">
+				<div class="column one">
+					<span property="itemListElement" typeof="ListItem"><a property="item" typeof="WebPage" title="Go to Murrow College of Communication." href="http://stage.murrow.wsu.edu" class="home"><span property="name">Murrow College of Communication</span></a><meta property="position" content="1"></span> / <span property="itemListElement" typeof="ListItem"><a property="item" typeof="WebPage" title="Go to Student Work." href="http://stage.murrow.wsu.edu/student-work/" class="post post-page"><span property="name">Student Work</span></a><meta property="position" content="2"></span> / <span property="itemListElement" typeof="ListItem"><span property="name">Backpack Journalism &amp; Global Expeditions</span><meta property="position" content="3"></span>
+				</div>
+			</section>
+
+			<div id="page-197" class="post-197 page type-page status-publish has-post-thumbnail hentry category-student-work wsuwp_university_org-edward-r-murrow-college-of-communication">
+				<div class="featured-image-wrapper">
+					<figure class="featured-image " style="background-image: url('https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-1188x430.jpg');">
+						<img width="792" height="287" src="https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-792x287.jpg" class="attachment-spine-medium_size size-spine-medium_size wp-post-image" alt="" srcset="https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-792x287.jpg 792w, https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-396x143.jpg 396w, https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-768x278.jpg 768w, https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-990x358.jpg 990w, https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/07/IMG_1128-e1501435515797-1188x430.jpg 1188w" sizes="(max-width: 792px) 100vw, 792px">
+					</figure>
+				</div>
+
   				<section id="builder-section-1496265321861" class="row side-right gutter">
-  						<header>
-  					<h1>Beyond the Classroom</h1>
-  				</header>
-  								<div style="" class="column one ">
+				    <header>
+					    <h1>Beyond the Classroom</h1>
+				    </header>
 
+				    <div style="" class="column one ">
+					    <p>True to our legacy, the Edward R. Murrow College of Communication is dedicated to providing students—the communications professionals of the future—this same level of inspiration, experience, and real-world education.</p>
+				    </div>
 
-
-  <p>True to our legacy, the Edward R. Murrow College of Communication is dedicated to providing students—the communications professionals of the future—this same level of inspiration, experience, and real-world education.</p>
-
-  				</div>
-  							<div style="" class="column two ">
-
-
-
-  				</div>
+				    <div style="" class="column two ">
+				    </div>
   				</section>
-  <section id="builder-section-1501353388815" class="row side-right gutter pad-top">
-  								<div style="" class="column one ">
 
-  																	<header>
-  							<h2>Student Stories</h2>
-  						</header>
+				<section id="builder-section-1501353388815" class="row side-right gutter pad-top">
+					<div style="" class="column one ">
+						<header>
+							<h2>Student Stories</h2>
+						</header>
 
-  											<p>Murrow students are storytellers who engage in collaborative learning experiences that span the globe, from the rolling hills of the Palouse to the mountains of Nepal.</p>
-  <h4>Recent stories</h4>
-  <p>&lt;!–would be great if we could display the three most recent posts with the category “Student Stories” here&gt;</p>
-  <p>Explore more&nbsp;<a href="https://stage.murrow.wsu.edu/student-work/student-stories/"><strong>student stories</strong></a></p>
+						<p>Murrow students are storytellers who engage in collaborative learning experiences that span the globe, from the rolling hills of the Palouse to the mountains of Nepal.</p>
 
-  				</div>
-  							<div style="" class="column two ">
+						<h4>Recent stories</h4>
+						<p>&lt;!–would be great if we could display the three most recent posts with the category “Student Stories” here&gt;</p>
+						<p>Explore more&nbsp;<a href="https://stage.murrow.wsu.edu/student-work/student-stories/"><strong>student stories</strong></a></p>
+					</div>
 
+					<div style="" class="column two ">
+					</div>
+				</section>
 
+				<section id="builder-section-1501352786146" class="row side-right gutter pad-top">
+					<div style="" class="column one ">
+						<header>
+							<h2>Student Media</h2>
+						</header>
 
-  				</div>
+						<h3 class="p1">Murrow News 8</h3>
+
+						<p class="p2"><span class="s1">Murrow News 8 is a nightly newscast produced, written, anchored and crewed entirely by students from the Edward R. Murrow College of Communication.</span></p>
+						<p><a href="https://stage.murrow.wsu.edu/student-work/murrow-news-8/">Learn more about Murrow News 8</a></p>
+						<h3 class="p2"><span class="s1">Murrow News Service</span></h3>
+						<p class="p2"><span class="s1">The Murrow News Service was created to provide students with experience in creating professional news stories, as well as to provide information to the public and media outlets. NWPR and NWPTV are trusted sources of quality content; students working within these properties get hands-on experience writing, editing, and producing content for a professional, statewide public radio and television service.</span></p>
+						<p><a href="https://stage.murrow.wsu.edu/student-work/murrow-news-service/">Learn more about Murrow News Service</a></p>
+						<h3 class="p1"></h3>
+						<h4 class="p1"></h4>
+					</div>
+
+					<div style="" class="column two ">
+					</div>
   				</section>
-  	<section id="builder-section-1501352786146" class="row side-right gutter pad-top">
-  								<div style="" class="column one ">
 
-  																	<header>
-  							<h2>Student Media</h2>
-  						</header>
+				<section id="builder-section-1501352494836" class="row side-right gutter pad-top">
+					<div style="" class="column one ">
+						<header>
+							<h2>Global Learning Experiences</h2>
+						</header>
 
-  											<h3 class="p1">Murrow News 8</h3>
-  <p class="p2"><span class="s1">Murrow News 8 is a nightly newscast produced, written, anchored and crewed entirely by students from the Edward R. Murrow College of Communication.</span></p>
-  <p><a href="https://stage.murrow.wsu.edu/student-work/murrow-news-8/">Learn more about Murrow News 8</a></p>
-  <h3 class="p2"><span class="s1">Murrow News Service</span></h3>
-  <p class="p2"><span class="s1">The Murrow News Service was created to provide students with experience in creating professional news stories, as well as to provide information to the public and media outlets. NWPR and NWPTV are trusted sources of quality content; students working within these properties get hands-on experience writing, editing, and producing content for a professional, statewide public radio and television service.</span></p>
-  <p><a href="https://stage.murrow.wsu.edu/student-work/murrow-news-service/">Learn more about Murrow News Service</a></p>
-  <h3 class="p1"></h3>
-  <h4 class="p1"></h4>
+						<h3 class="p1">Backpack Journalism</h3>
+						<p class="p2"><span class="s1">The Murrow Backpack Journalism program provides a unique opportunity for the most accomplished students in the college to travel abroad and work in an international environment. Backpack Journalism students experience the challenges and benefits of international travel, may have their work published by professional media and enrich their academic and professional lives.</span></p>
+						<p><a href="https://stage.murrow.wsu.edu/student-work/backpack-journalism-global-expeditions/">Learn more about Backpack Journalism</a></p>
+						<h3 class="p1">Backpack Environmental</h3>
+						<p class="p2"><span class="s1">Murrow students who love nature, the Earth, and need to be the first to know about groundbreaking environmental science can be a part of the Backpack Environmental program. Student journalists travel around the country and work side-by-side with environmental scientists conducting cutting-edge experiments, and have the opportunity to profile their work.</span></p>
+						<p><a href="https://stage.murrow.wsu.edu/student-work/backpack-journalism-global-expeditions/">Learn more about Backpack Environmental</a></p>
+						<h3 class="p1">Study Abroad: Murrow Global Expeditions</h3>
+						<p class="p2"><span class="s1">The mission in May 2017: for students to find their own stories while immersed in two incredible international locations. “Havana, Pearl of the Caribbean,” will mark our fourth Global Expedition to this cultural treasure, now open to U.S. Citizens after decades of political and social isolation. A new program, “Epic Stories of Greece,” offers an unforgettable one-month learning experience in Thessaloniki, Greece.</span></p>
+						<p><a href="https://stage.murrow.wsu.edu/student-work/backpack-journalism-global-expeditions/">Learn more about Global Expeditions</a></p>
+						<h3 class="p1"></h3>
+					</div>
 
-  				</div>
-  							<div style="" class="column two ">
-
-
-
-  				</div>
+					<div style="" class="column two ">
+					</div>
   				</section>
-  	<section id="builder-section-1501352494836" class="row side-right gutter pad-top">
-  								<div style="" class="column one ">
 
-  																	<header>
-  							<h2>Global Learning Experiences</h2>
-  						</header>
+				<section id="builder-section-1496876373135" class="row side-right gutter pad-top">
+					<div style="" class="column one ">
+						<header>
+							<h2>Internships</h2>
+						</header>
+						<p class="p2"><span class="s1">We have established relationships with major media companies, public relations, and advertising agencies. Dedicated Career Services staff keeps students connected to internship and job opportunities, and our strong corporate partners like Boeing and the Seahawks, students with professional networking and resume building connections. </span></p>
+					</div>
 
-  											<h3 class="p1">Backpack Journalism</h3>
-  <p class="p2"><span class="s1">The Murrow Backpack Journalism program provides a unique opportunity for the most accomplished students in the college to travel abroad and work in an international environment. Backpack Journalism students experience the challenges and benefits of international travel, may have their work published by professional media and enrich their academic and professional lives.</span></p>
-  <p><a href="https://stage.murrow.wsu.edu/student-work/backpack-journalism-global-expeditions/">Learn more about Backpack Journalism</a></p>
-  <h3 class="p1">Backpack Environmental</h3>
-  <p class="p2"><span class="s1">Murrow students who love nature, the Earth, and need to be the first to know about groundbreaking environmental science can be a part of the Backpack Environmental program. Student journalists travel around the country and work side-by-side with environmental scientists conducting cutting-edge experiments, and have the opportunity to profile their work.</span></p>
-  <p><a href="https://stage.murrow.wsu.edu/student-work/backpack-journalism-global-expeditions/">Learn more about Backpack Environmental</a></p>
-  <h3 class="p1">Study Abroad: Murrow Global Expeditions</h3>
-  <p class="p2"><span class="s1">The mission in May 2017: for students to find their own stories while immersed in two incredible international locations. “Havana, Pearl of the Caribbean,” will mark our fourth Global Expedition to this cultural treasure, now open to U.S. Citizens after decades of political and social isolation. A new program, “Epic Stories of Greece,” offers an unforgettable one-month learning experience in Thessaloniki, Greece.</span></p>
-  <p><a href="https://stage.murrow.wsu.edu/student-work/backpack-journalism-global-expeditions/">Learn more about Global Expeditions</a></p>
-  <h3 class="p1"></h3>
+					<div style="" class="column two ">
+					</div>
+				</section>
 
-  				</div>
-  							<div style="" class="column two ">
+				<section id="builder-section-1501354050278" class="row side-right gutter pad-top">
+					<div style="" class="column one ">
+						<header>
+							<h2>Student Clubs and Organizations</h2>
+						</header>
 
+						<p>Need a description here</p>
+						<p>Find a <a href="https://stage.murrow.wsu.edu/student-work/student-clubs-organizations/"><strong>student club or organization</strong></a> that matches your interests</p>
+					</div>
 
+					<div style="" class="column two ">
+					</div>
+				</section>
 
-  				</div>
-  				</section>
-  	<section id="builder-section-1496876373135" class="row side-right gutter pad-top">
-  								<div style="" class="column one ">
+				<section id="builder-section-1501353119665" class="row side-right gutter pad-top">
+					<div style="" class="column one ">
+						<header>
+							<h2>Awards and Achievements</h2>
+						</header>
+						<p class="p2"><span class="s1">Murrow students are regularly featured and granted awards by the American Advertising Federation, PRSSA’s Bateman Case Study Competition, the Society of Professional Journalism, the National Academy of Television Arts and Sciences, and the National Student Advertising Competition. Each of these organizations provides professional networking, career development and real-world experiences that put our students at an advantage in the workplace.</span></p>
+						<p>See our recent student and faculty awards (need a link to posts tagged as “Awards”)</p>
+					</div>
 
-  																	<header>
-  							<h2>Internships</h2>
-  						</header>
-
-  											<p class="p2"><span class="s1">We have established relationships with major media companies, public relations, and advertising agencies. Dedicated Career Services staff keeps students connected to internship and job opportunities, and our strong corporate partners like Boeing and the Seahawks, students with professional networking and resume building connections. </span></p>
-
-  				</div>
-  							<div style="" class="column two ">
-
-
-
-  				</div>
-  				</section>
-  	<section id="builder-section-1501354050278" class="row side-right gutter pad-top">
-  								<div style="" class="column one ">
-
-  																	<header>
-  							<h2>Student Clubs and Organizations</h2>
-  						</header>
-
-  											<p>Need a description here</p>
-  <p>Find a <a href="https://stage.murrow.wsu.edu/student-work/student-clubs-organizations/"><strong>student club or organization</strong></a> that matches your interests</p>
-
-  				</div>
-  							<div style="" class="column two ">
-
-
-
-  				</div>
-  				</section>
-  	<section id="builder-section-1501353119665" class="row side-right gutter pad-top">
-  								<div style="" class="column one ">
-
-  																	<header>
-  							<h2>Awards and Achievements</h2>
-  						</header>
-
-  											<p class="p2"><span class="s1">Murrow students are regularly featured and granted awards by the American Advertising Federation, PRSSA’s Bateman Case Study Competition, the Society of Professional Journalism, the National Academy of Television Arts and Sciences, and the National Student Advertising Competition. Each of these organizations provides professional networking, career development and real-world experiences that put our students at an advantage in the workplace.</span></p>
-  <p>See our recent student and faculty awards (need a link to posts tagged as “Awards”)</p>
-
-  				</div>
-  							<div style="" class="column two ">
-
-
-
-  				</div>
-  				</section>
-  			</div>
-</main>
-
-</div><!--/binder-->
+					<div style="" class="column two ">
+					</div>
+				</section>
+			</div>
+		</main>
+	</div><!--/binder-->
 </div><!--/jacket-->
+
 <div id="contact-details" itemscope itemtype="http://schema.org/Organization">
 <meta itemprop="name" class="required" content="Washington State University">
 <meta itemprop="department" class="required" content="">

--- a/style-guide/tertiary.html
+++ b/style-guide/tertiary.html
@@ -40,239 +40,239 @@
 </head>
 
 <body class="page-template page-template-template-builder page-template-template-builder-php page opensansy single depth-0">
-	<a href="#wsuwp-main" class="screen-reader-shortcut">Skip to main content</a>
-	<a href="#spine-sitenav" class="screen-reader-shortcut">Skip to navigation</a>
-	<div id="jacket" class="style-skeletal colors-default spacing-default">
-		<div id="binder" class="fluid folio max-1188">
-			<div class="global-bar-wrap">
-				<div class="global-bar">
-					<a class="global-home" href="https://wsu.edu">Washington State University</a>
-				</div>
+<a href="#wsuwp-main" class="screen-reader-shortcut">Skip to main content</a>
+<a href="#spine-sitenav" class="screen-reader-shortcut">Skip to navigation</a>
+<div id="jacket" class="style-skeletal colors-default spacing-default">
+	<div id="binder" class="fluid folio max-1188">
+		<div class="global-bar-wrap">
+			<div class="global-bar">
+				<a class="global-home" href="https://wsu.edu">Washington State University</a>
 			</div>
-			<div id="contact-search" class="site-search">
-				<ul>
-					<li class="menu-item menu-item-type-post_type menu-item-object-page"><a href="#">Contact</a></li>
-					<li class="search">
-						<form role="search" method="get" class="search-form" action="">
-							<label>
-								<span class="screen-reader-text">Search for:</span>
-								<input type="search" class="search-field" placeholder="Search &hellip;" value="" name="s" />
-							</label>
-							<input type="submit" class="search-submit" value="Search" />
-						</form>
-					</li>
-				</ul>
-			</div>
+		</div>
+		<div id="contact-search" class="site-search">
+			<ul>
+				<li class="menu-item menu-item-type-post_type menu-item-object-page"><a href="#">Contact</a></li>
+				<li class="search">
+					<form role="search" method="get" class="search-form" action="">
+						<label>
+							<span class="screen-reader-text">Search for:</span>
+							<input type="search" class="search-field" placeholder="Search &hellip;" value="" name="s" />
+						</label>
+						<input type="submit" class="search-submit" value="Search" />
+					</form>
+				</li>
+			</ul>
+		</div>
 
-			<div id="spine" class="spine-column darker search-closed shelved">
-				<div id="glue" class="spine-glue">
-					<header class="spine-header">
-						<a href="https://murrow.wsu.edu" id="wsu-signature">Edward R. Murrow College of Communication</a>
-					</header>
-					<section id="wsu-actions" class="spine-actions clearfix">
-						<ul id="wsu-actions-tabs" class="spine-actions-tabs spine-tabs clearfix">
-							<li id="wsu-search-tab" class="spine-search-tab closed"><button>Search</button></li>
-							<li id="wsu-contact-tab" class="spine-contact-tab closed"><button>Contact</button></li>
-							<li id="wsu-share-tab" class="spine-share-tab closed"><button>Share</button></li>
+		<div id="spine" class="spine-column darker search-closed shelved">
+			<div id="glue" class="spine-glue">
+				<header class="spine-header">
+					<a href="https://murrow.wsu.edu" id="wsu-signature">Edward R. Murrow College of Communication</a>
+				</header>
+				<section id="wsu-actions" class="spine-actions clearfix">
+					<ul id="wsu-actions-tabs" class="spine-actions-tabs spine-tabs clearfix">
+						<li id="wsu-search-tab" class="spine-search-tab closed"><button>Search</button></li>
+						<li id="wsu-contact-tab" class="spine-contact-tab closed"><button>Contact</button></li>
+						<li id="wsu-share-tab" class="spine-share-tab closed"><button>Share</button></li>
+					</ul>
+				</section><!--/#wsu-actions-->
+				<section id="spine-navigation" class="spine-navigation">
+					<nav id="spine-sitenav" class="spine-sitenav">
+						<ul>
+							<li class="active"><a href="#">Communications Home</a></li>
+							<li><a href="#">About</a>
+								<ul class="sub-menu">
+									<li><a href="#">Dean&#8217;s Message</a></li>
+									<li><a href="#">Mission Statement</a></li>
+								</ul>
+							</li>
+							<li><a href="#">Academics</a>
+								<ul class="sub-menu">
+									<li><a href="#">Undergraduate Studies</a></li>
+									<li><a href="#">Graduate Studies</a></li>
+								</ul>
+							</li>
+							<li><a href="#">News</a></li>
 						</ul>
-					</section><!--/#wsu-actions-->
-					<section id="spine-navigation" class="spine-navigation">
-						<nav id="spine-sitenav" class="spine-sitenav">
-							<ul>
-								<li class="active"><a href="#">Communications Home</a></li>
-								<li><a href="#">About</a>
-									<ul class="sub-menu">
-										<li><a href="#">Dean&#8217;s Message</a></li>
-										<li><a href="#">Mission Statement</a></li>
-									</ul>
-								</li>
-								<li><a href="#">Academics</a>
-									<ul class="sub-menu">
-										<li><a href="#">Undergraduate Studies</a></li>
-										<li><a href="#">Graduate Studies</a></li>
-									</ul>
-								</li>
-								<li><a href="#">News</a></li>
-							</ul>
-						</nav>
-						<nav id="spine-offsitenav" class="spine-offsitenav"></nav>
-					</section>
-					<footer class="spine-footer">
-						<nav id="wsu-social-channels" class="spine-social-channels">
-							<ul>
-								<li class="facebook-channel"><a href="https://www.facebook.com/WSUPullman">facebook</a></li>
-								<li class="twitter-channel"><a href="https://twitter.com/wsupullman">twitter</a></li>
-								<li class="youtube-channel"><a href="https://www.youtube.com/washingtonstateuniv">youtube</a></li>
-								<li class="directory-channel"><a href="http://social.wsu.edu">directory</a></li>
-							</ul>
-						</nav>
-						<nav id="wsu-global-links" class="spine-global-links">
-							<ul>
-								<li class="mywsu-link"><a href="https://portal.wsu.edu/">myWSU</a></li>
-								<li class="access-link"><a href="https://access.wsu.edu/">Access</a></li>
-								<li class="policies-link"><a href="https://policies.wsu.edu/">Policies</a></li>
-								<li class="copyright-link"><a href="https://copyright.wsu.edu">&copy;</a></li>
-							</ul>
-						</nav>
-					</footer>
-				</div><!--/glue-->
-			</div><!--/spine-->
+					</nav>
+					<nav id="spine-offsitenav" class="spine-offsitenav"></nav>
+				</section>
+				<footer class="spine-footer">
+					<nav id="wsu-social-channels" class="spine-social-channels">
+						<ul>
+							<li class="facebook-channel"><a href="https://www.facebook.com/WSUPullman">facebook</a></li>
+							<li class="twitter-channel"><a href="https://twitter.com/wsupullman">twitter</a></li>
+							<li class="youtube-channel"><a href="https://www.youtube.com/washingtonstateuniv">youtube</a></li>
+							<li class="directory-channel"><a href="http://social.wsu.edu">directory</a></li>
+						</ul>
+					</nav>
+					<nav id="wsu-global-links" class="spine-global-links">
+						<ul>
+							<li class="mywsu-link"><a href="https://portal.wsu.edu/">myWSU</a></li>
+							<li class="access-link"><a href="https://access.wsu.edu/">Access</a></li>
+							<li class="policies-link"><a href="https://policies.wsu.edu/">Policies</a></li>
+							<li class="copyright-link"><a href="https://copyright.wsu.edu">&copy;</a></li>
+						</ul>
+					</nav>
+				</footer>
+			</div><!--/glue-->
+		</div><!--/spine-->
 
-			<main id="wsuwp-main" class="spine-blank-template">
-				<section class="row single breadcrumbs breadcrumbs-top gutter pad-top" typeof="BreadcrumbList" vocab="http://schema.org/">
-		<div class="column one">
-			<span property="itemListElement" typeof="ListItem"><a property="item" typeof="WebPage" title="Go to Murrow College of Communication." href="http://stage.murrow.wsu.edu" class="home"><span property="name">Murrow College of Communication</span></a><meta property="position" content="1"></span> / <span property="itemListElement" typeof="ListItem"><a property="item" typeof="WebPage" title="Go to Student Work." href="http://stage.murrow.wsu.edu/student-work/" class="post post-page"><span property="name">Student Work</span></a><meta property="position" content="2"></span> / <span property="itemListElement" typeof="ListItem"><span property="name">Backpack Journalism &amp; Global Expeditions</span><meta property="position" content="3"></span>		</div>
-	</section>
-  <div id="page-197" class="post-197 page type-page status-publish has-post-thumbnail hentry category-student-work wsuwp_university_org-edward-r-murrow-college-of-communication">
-  				<section id="builder-section-1496265321861" class="row side-right gutter">
-  						<header>
-  					<h1>Beyond the Classroom</h1>
-  				</header>
-  								<div style="" class="column one ">
+		<main id="wsuwp-main" class="spine-blank-template">
+			<section class="row single breadcrumbs breadcrumbs-top gutter pad-top" typeof="BreadcrumbList" vocab="http://schema.org/">
+				<div class="column one">
+					<span property="itemListElement" typeof="ListItem"><a property="item" typeof="WebPage" title="Go to Murrow College of Communication." href="http://stage.murrow.wsu.edu" class="home"><span property="name">Murrow College of Communication</span></a><meta property="position" content="1"></span> / <span property="itemListElement" typeof="ListItem"><a property="item" typeof="WebPage" title="Go to Student Work." href="http://stage.murrow.wsu.edu/student-work/" class="post post-page"><span property="name">Student Work</span></a><meta property="position" content="2"></span> / <span property="itemListElement" typeof="ListItem"><span property="name">Backpack Journalism &amp; Global Expeditions</span><meta property="position" content="3"></span>		</div>
+			</section>
+			<div id="page-197" class="post-197 page type-page status-publish has-post-thumbnail hentry category-student-work wsuwp_university_org-edward-r-murrow-college-of-communication">
+				<section id="builder-section-1496265321861" class="row side-right gutter">
+					<header>
+						<h1>Beyond the Classroom</h1>
+					</header>
+					<div style="" class="column one ">
 
 
 
-  <p>True to our legacy, the Edward R. Murrow College of Communication is dedicated to providing students—the communications professionals of the future—this same level of inspiration, experience, and real-world education.</p>
+						<p>True to our legacy, the Edward R. Murrow College of Communication is dedicated to providing students—the communications professionals of the future—this same level of inspiration, experience, and real-world education.</p>
 
-  				</div>
-  							<div style="" class="column two ">
-
-
-
-  				</div>
-  				</section>
-  <section id="builder-section-1501353388815" class="row side-right gutter pad-top">
-  								<div style="" class="column one ">
-
-  																	<header>
-  							<h2>Student Stories</h2>
-  						</header>
-
-  											<p>Murrow students are storytellers who engage in collaborative learning experiences that span the globe, from the rolling hills of the Palouse to the mountains of Nepal.</p>
-  <h4>Recent stories</h4>
-  <p>&lt;!–would be great if we could display the three most recent posts with the category “Student Stories” here&gt;</p>
-  <p>Explore more&nbsp;<a href="https://stage.murrow.wsu.edu/student-work/student-stories/"><strong>student stories</strong></a></p>
-
-  				</div>
-  							<div style="" class="column two ">
+					</div>
+					<div style="" class="column two ">
 
 
 
-  				</div>
-  				</section>
-  	<section id="builder-section-1501352786146" class="row side-right gutter pad-top">
-  								<div style="" class="column one ">
+					</div>
+				</section>
+				<section id="builder-section-1501353388815" class="row side-right gutter pad-top">
+					<div style="" class="column one ">
 
-  																	<header>
-  							<h2>Student Media</h2>
-  						</header>
+						<header>
+							<h2>Student Stories</h2>
+						</header>
 
-  											<h3 class="p1">Murrow News 8</h3>
-  <p class="p2"><span class="s1">Murrow News 8 is a nightly newscast produced, written, anchored and crewed entirely by students from the Edward R. Murrow College of Communication.</span></p>
-  <p><a href="https://stage.murrow.wsu.edu/student-work/murrow-news-8/">Learn more about Murrow News 8</a></p>
-  <h3 class="p2"><span class="s1">Murrow News Service</span></h3>
-  <p class="p2"><span class="s1">The Murrow News Service was created to provide students with experience in creating professional news stories, as well as to provide information to the public and media outlets. NWPR and NWPTV are trusted sources of quality content; students working within these properties get hands-on experience writing, editing, and producing content for a professional, statewide public radio and television service.</span></p>
-  <p><a href="https://stage.murrow.wsu.edu/student-work/murrow-news-service/">Learn more about Murrow News Service</a></p>
-  <h3 class="p1"></h3>
-  <h4 class="p1"></h4>
+						<p>Murrow students are storytellers who engage in collaborative learning experiences that span the globe, from the rolling hills of the Palouse to the mountains of Nepal.</p>
+						<h4>Recent stories</h4>
+						<p>&lt;!–would be great if we could display the three most recent posts with the category “Student Stories” here&gt;</p>
+						<p>Explore more&nbsp;<a href="https://stage.murrow.wsu.edu/student-work/student-stories/"><strong>student stories</strong></a></p>
 
-  				</div>
-  							<div style="" class="column two ">
+					</div>
+					<div style="" class="column two ">
 
 
 
-  				</div>
-  				</section>
-  	<section id="builder-section-1501352494836" class="row side-right gutter pad-top">
-  								<div style="" class="column one ">
+					</div>
+				</section>
+				<section id="builder-section-1501352786146" class="row side-right gutter pad-top">
+					<div style="" class="column one ">
 
-  																	<header>
-  							<h2>Global Learning Experiences</h2>
-  						</header>
+						<header>
+							<h2>Student Media</h2>
+						</header>
 
-  											<h3 class="p1">Backpack Journalism</h3>
-  <p class="p2"><span class="s1">The Murrow Backpack Journalism program provides a unique opportunity for the most accomplished students in the college to travel abroad and work in an international environment. Backpack Journalism students experience the challenges and benefits of international travel, may have their work published by professional media and enrich their academic and professional lives.</span></p>
-  <p><a href="https://stage.murrow.wsu.edu/student-work/backpack-journalism-global-expeditions/">Learn more about Backpack Journalism</a></p>
-  <h3 class="p1">Backpack Environmental</h3>
-  <p class="p2"><span class="s1">Murrow students who love nature, the Earth, and need to be the first to know about groundbreaking environmental science can be a part of the Backpack Environmental program. Student journalists travel around the country and work side-by-side with environmental scientists conducting cutting-edge experiments, and have the opportunity to profile their work.</span></p>
-  <p><a href="https://stage.murrow.wsu.edu/student-work/backpack-journalism-global-expeditions/">Learn more about Backpack Environmental</a></p>
-  <h3 class="p1">Study Abroad: Murrow Global Expeditions</h3>
-  <p class="p2"><span class="s1">The mission in May 2017: for students to find their own stories while immersed in two incredible international locations. “Havana, Pearl of the Caribbean,” will mark our fourth Global Expedition to this cultural treasure, now open to U.S. Citizens after decades of political and social isolation. A new program, “Epic Stories of Greece,” offers an unforgettable one-month learning experience in Thessaloniki, Greece.</span></p>
-  <p><a href="https://stage.murrow.wsu.edu/student-work/backpack-journalism-global-expeditions/">Learn more about Global Expeditions</a></p>
-  <h3 class="p1"></h3>
+						<h3 class="p1">Murrow News 8</h3>
+						<p class="p2"><span class="s1">Murrow News 8 is a nightly newscast produced, written, anchored and crewed entirely by students from the Edward R. Murrow College of Communication.</span></p>
+						<p><a href="https://stage.murrow.wsu.edu/student-work/murrow-news-8/">Learn more about Murrow News 8</a></p>
+						<h3 class="p2"><span class="s1">Murrow News Service</span></h3>
+						<p class="p2"><span class="s1">The Murrow News Service was created to provide students with experience in creating professional news stories, as well as to provide information to the public and media outlets. NWPR and NWPTV are trusted sources of quality content; students working within these properties get hands-on experience writing, editing, and producing content for a professional, statewide public radio and television service.</span></p>
+						<p><a href="https://stage.murrow.wsu.edu/student-work/murrow-news-service/">Learn more about Murrow News Service</a></p>
+						<h3 class="p1"></h3>
+						<h4 class="p1"></h4>
 
-  				</div>
-  							<div style="" class="column two ">
+					</div>
+					<div style="" class="column two ">
 
 
 
-  				</div>
-  				</section>
-  	<section id="builder-section-1496876373135" class="row side-right gutter pad-top">
-  								<div style="" class="column one ">
+					</div>
+				</section>
+				<section id="builder-section-1501352494836" class="row side-right gutter pad-top">
+					<div style="" class="column one ">
 
-  																	<header>
-  							<h2>Internships</h2>
-  						</header>
+						<header>
+							<h2>Global Learning Experiences</h2>
+						</header>
 
-  											<p class="p2"><span class="s1">We have established relationships with major media companies, public relations, and advertising agencies. Dedicated Career Services staff keeps students connected to internship and job opportunities, and our strong corporate partners like Boeing and the Seahawks, students with professional networking and resume building connections. </span></p>
+						<h3 class="p1">Backpack Journalism</h3>
+						<p class="p2"><span class="s1">The Murrow Backpack Journalism program provides a unique opportunity for the most accomplished students in the college to travel abroad and work in an international environment. Backpack Journalism students experience the challenges and benefits of international travel, may have their work published by professional media and enrich their academic and professional lives.</span></p>
+						<p><a href="https://stage.murrow.wsu.edu/student-work/backpack-journalism-global-expeditions/">Learn more about Backpack Journalism</a></p>
+						<h3 class="p1">Backpack Environmental</h3>
+						<p class="p2"><span class="s1">Murrow students who love nature, the Earth, and need to be the first to know about groundbreaking environmental science can be a part of the Backpack Environmental program. Student journalists travel around the country and work side-by-side with environmental scientists conducting cutting-edge experiments, and have the opportunity to profile their work.</span></p>
+						<p><a href="https://stage.murrow.wsu.edu/student-work/backpack-journalism-global-expeditions/">Learn more about Backpack Environmental</a></p>
+						<h3 class="p1">Study Abroad: Murrow Global Expeditions</h3>
+						<p class="p2"><span class="s1">The mission in May 2017: for students to find their own stories while immersed in two incredible international locations. “Havana, Pearl of the Caribbean,” will mark our fourth Global Expedition to this cultural treasure, now open to U.S. Citizens after decades of political and social isolation. A new program, “Epic Stories of Greece,” offers an unforgettable one-month learning experience in Thessaloniki, Greece.</span></p>
+						<p><a href="https://stage.murrow.wsu.edu/student-work/backpack-journalism-global-expeditions/">Learn more about Global Expeditions</a></p>
+						<h3 class="p1"></h3>
 
-  				</div>
-  							<div style="" class="column two ">
-
-
-
-  				</div>
-  				</section>
-  	<section id="builder-section-1501354050278" class="row side-right gutter pad-top">
-  								<div style="" class="column one ">
-
-  																	<header>
-  							<h2>Student Clubs and Organizations</h2>
-  						</header>
-
-  											<p>Need a description here</p>
-  <p>Find a <a href="https://stage.murrow.wsu.edu/student-work/student-clubs-organizations/"><strong>student club or organization</strong></a> that matches your interests</p>
-
-  				</div>
-  							<div style="" class="column two ">
+					</div>
+					<div style="" class="column two ">
 
 
 
-  				</div>
-  				</section>
-  	<section id="builder-section-1501353119665" class="row side-right gutter pad-top">
-  								<div style="" class="column one ">
+					</div>
+				</section>
+				<section id="builder-section-1496876373135" class="row side-right gutter pad-top">
+					<div style="" class="column one ">
 
-  																	<header>
-  							<h2>Awards and Achievements</h2>
-  						</header>
+						<header>
+							<h2>Internships</h2>
+						</header>
 
-  											<p class="p2"><span class="s1">Murrow students are regularly featured and granted awards by the American Advertising Federation, PRSSA’s Bateman Case Study Competition, the Society of Professional Journalism, the National Academy of Television Arts and Sciences, and the National Student Advertising Competition. Each of these organizations provides professional networking, career development and real-world experiences that put our students at an advantage in the workplace.</span></p>
-  <p>See our recent student and faculty awards (need a link to posts tagged as “Awards”)</p>
+						<p class="p2"><span class="s1">We have established relationships with major media companies, public relations, and advertising agencies. Dedicated Career Services staff keeps students connected to internship and job opportunities, and our strong corporate partners like Boeing and the Seahawks, students with professional networking and resume building connections. </span></p>
 
-  				</div>
-  							<div style="" class="column two ">
-
+					</div>
+					<div style="" class="column two ">
 
 
-  				</div>
-  				</section>
-  			</div>
-</main>
 
-</div><!--/binder-->
+					</div>
+				</section>
+				<section id="builder-section-1501354050278" class="row side-right gutter pad-top">
+					<div style="" class="column one ">
+
+						<header>
+							<h2>Student Clubs and Organizations</h2>
+						</header>
+
+						<p>Need a description here</p>
+						<p>Find a <a href="https://stage.murrow.wsu.edu/student-work/student-clubs-organizations/"><strong>student club or organization</strong></a> that matches your interests</p>
+
+					</div>
+					<div style="" class="column two ">
+
+
+
+					</div>
+				</section>
+				<section id="builder-section-1501353119665" class="row side-right gutter pad-top">
+					<div style="" class="column one ">
+
+						<header>
+							<h2>Awards and Achievements</h2>
+						</header>
+
+						<p class="p2"><span class="s1">Murrow students are regularly featured and granted awards by the American Advertising Federation, PRSSA’s Bateman Case Study Competition, the Society of Professional Journalism, the National Academy of Television Arts and Sciences, and the National Student Advertising Competition. Each of these organizations provides professional networking, career development and real-world experiences that put our students at an advantage in the workplace.</span></p>
+						<p>See our recent student and faculty awards (need a link to posts tagged as “Awards”)</p>
+
+					</div>
+					<div style="" class="column two ">
+
+
+
+					</div>
+				</section>
+			</div>
+		</main>
+
+	</div><!--/binder-->
 </div><!--/jacket-->
 <div id="contact-details" itemscope itemtype="http://schema.org/Organization">
-<meta itemprop="name" class="required" content="Washington State University">
-<meta itemprop="department" class="required" content="">
-<div itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
-<meta itemprop="streetAddress" class="optional" content="PO Box 641227">
-<meta itemprop="addressLocality" class="optional" content="Pullman, WA">
-<meta itemprop="postalCode" class="required" content="99164">
-</div>
-<meta itemprop="telephone" class="required" content="(509) 335-3564">
-<meta itemprop="email" class="required" content="info@wsu.edu">
+	<meta itemprop="name" class="required" content="Washington State University">
+	<meta itemprop="department" class="required" content="">
+	<div itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+		<meta itemprop="streetAddress" class="optional" content="PO Box 641227">
+		<meta itemprop="addressLocality" class="optional" content="Pullman, WA">
+		<meta itemprop="postalCode" class="required" content="99164">
+	</div>
+	<meta itemprop="telephone" class="required" content="(509) 335-3564">
+	<meta itemprop="email" class="required" content="info@wsu.edu">
 </div>
 <script type='text/javascript' src='https://web.wsu.edu/wp-content/themes/spine/js/spine-theme.js?ver=0.27.10-1.6.4-40891'></script>
 <script type='text/javascript' src='https://web.wsu.edu/wp-includes/js/wp-embed.min.js?ver=4.8'></script>

--- a/style-guide/tertiary.html
+++ b/style-guide/tertiary.html
@@ -124,6 +124,12 @@
 					<span property="itemListElement" typeof="ListItem"><a property="item" typeof="WebPage" title="Go to Murrow College of Communication." href="http://stage.murrow.wsu.edu" class="home"><span property="name">Murrow College of Communication</span></a><meta property="position" content="1"></span> / <span property="itemListElement" typeof="ListItem"><a property="item" typeof="WebPage" title="Go to Student Work." href="http://stage.murrow.wsu.edu/student-work/" class="post post-page"><span property="name">Student Work</span></a><meta property="position" content="2"></span> / <span property="itemListElement" typeof="ListItem"><span property="name">Backpack Journalism &amp; Global Expeditions</span><meta property="position" content="3"></span>		</div>
 			</section>
 			<div id="page-197" class="post-197 page type-page status-publish has-post-thumbnail hentry category-student-work wsuwp_university_org-edward-r-murrow-college-of-communication">
+				<div class="featured-image-wrapper">
+					<figure class="featured-image " style="background-image: url('https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/08/IMG_1128.jpg');">
+						<img width="792" height="287" src="https://stage.murrow.wsu.edu/wp-content/uploads/sites/880/2017/08/IMG_1128.jpg" class="attachment-spine-medium_size size-spine-medium_size wp-post-image" alt="">
+					</figure>
+				</div>
+
 				<section id="builder-section-1496265321861" class="row side-right gutter">
 					<header>
 						<h1>Beyond the Classroom</h1>

--- a/template-builder.php
+++ b/template-builder.php
@@ -25,7 +25,7 @@ get_header();
 
 					?>
 					<div class="featured-image-wrapper">
-						<figure class="featured-image <?php echo $featured_image_position; ?>" style="background-image: url('<?php echo esc_url( $featured_image_src ); ?>');"><?php spine_the_featured_image(); ?></figure>
+						<figure class="featured-image <?php echo esc_attr( $featured_image_position ); ?>" style="background-image: url('<?php echo esc_url( $featured_image_src ); ?>');"><?php spine_the_featured_image(); ?></figure>
 					</div><?php
 				}
 

--- a/template-builder.php
+++ b/template-builder.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Template Name: Builder Template
+ */
+
+get_header();
+?>
+	<main id="wsuwp-main" class="spine-blank-template">
+
+		<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
+
+			<?php get_template_part( 'parts/headers' ); ?>
+
+			<div id="page-<?php the_ID(); ?>" <?php post_class(); ?>>
+				<?php
+
+				// If a featured image is assigned to the post, output it as a figure with a background image accordingly.
+				if ( spine_has_featured_image() ) {
+					$featured_image_src = spine_get_featured_image_src();
+					$featured_image_position = get_post_meta( get_the_ID(), '_featured_image_position', true );
+
+					if ( ! $featured_image_position || sanitize_html_class( $featured_image_position ) !== $featured_image_position ) {
+						$featured_image_position = '';
+					}
+
+					?>
+					<div class="featured-image-wrapper">
+						<figure class="featured-image <?php echo $featured_image_position; ?>" style="background-image: url('<?php echo esc_url( $featured_image_src ); ?>');"><?php spine_the_featured_image(); ?></figure>
+					</div><?php
+				}
+
+				/**
+				 * `the_content` is fired on builder template pages while it is saved
+				 * rather than while it is output in order for some advanced tags to
+				 * survive the process and to avoid autop issues.
+				 */
+				remove_filter( 'the_content', 'wpautop', 10 );
+				add_filter( 'wsu_content_syndicate_host_data', 'spine_filter_local_content_syndicate_item', 10, 3 );
+				the_content();
+				remove_filter( 'wsu_content_syndicate_host_data', 'spine_filter_local_content_syndicate_item', 10 );
+				add_filter( 'the_content', 'wpautop', 10 );
+
+				?>
+			</div><!-- #post -->
+
+			<?php
+		endwhile;
+		endif;
+
+		get_template_part( 'parts/footers' );
+		?>
+	</main>
+<?php get_footer();


### PR DESCRIPTION
* Move featured image output inside main article `<div>` on all pages built with page builder.
* Add expected featured image output to tertiary page style guide.
* Disable support for thumbnail images on posts and pages. If we need to support multiple post thumbnails we can re-add in the future.

Fixes #44 