### PR TITLE
[PR] Ensure people/projects is not `false` before counting

### DIFF
--- a/articles/post.php
+++ b/articles/post.php
@@ -60,7 +60,7 @@ $subhead = get_post_meta( get_the_ID(), '_murrow_subhead', true );
 				$people = array();
 			}
 
-			if ( 0 < count( $people ) ) {
+			if ( $people && 0 < count( $people ) ) {
 				echo '<p class="meta-head meta-people">People</p>';
 				echo '<ul class="meta-item-list">';
 

--- a/wsu-people/person.php
+++ b/wsu-people/person.php
@@ -138,7 +138,7 @@ if ( false !== $display['directory_view'] ) { ?>
 		$projects = array();
 	}
 
-	if ( 0 < count( $projects ) ) {
+	if ( $projects && 0 < count( $projects ) ) {
 	?>
 	<div class="wsuwp-uc-projects row single padded-ends">
 		<div class="column one">


### PR DESCRIPTION
The UCO functions will return `false` if the requested object type is the same as the object being displayed. And `Invalid argument supplied for foreach()` appeared in the server logs a few times because `count( false )` is `1` in PHP 5.6 through PHP 7.1. See https://3v4l.org/Vur8v

I'm not exactly sure how often this would come up, but it doesn't hurt to be defensive and check for a truthy value before attempting to count it.