### PR TITLE
[PR] Set the `with_front` arg to false for people rewrites

### DIFF
--- a/includes/people-directory.php
+++ b/includes/people-directory.php
@@ -14,6 +14,7 @@ add_filter( 'wsuwp_people_default_rewrite_slug', 'WSU\Murrow\People_Directory\re
 function rewrite_arguments( $rewrite ) {
 	return array(
 		'slug' => 'people',
+		'with_front' => false,
 	);
 }
 


### PR DESCRIPTION
This gets rid of the `posts/` portion of the slug for people profiles.