### PR TITLE
[PR] Add Pageheader Sub in a Formats drop-down in TinyMCE

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,7 +3,7 @@ module.exports = function( grunt ) {
 		pkg: grunt.file.readJSON( "package.json" ),
 
 		stylelint: {
-			src: [ "css/*.css" ]
+			src: [ "css/*.css", "editor/*.css" ]
 		},
 
 		concat: {

--- a/editor/editor-style.css
+++ b/editor/editor-style.css
@@ -1,0 +1,207 @@
+body {
+	color: #424242;
+	font-weight: 300;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+	margin: 0;
+	line-height: 1.25em;
+	letter-spacing: 0;
+	font-weight: 700;
+	padding: .5em 0 .2em;
+}
+
+h1 {
+	color: #a60f2d;
+	font-size: 3.5em;
+	line-height: 1em;
+	text-transform: uppercase;
+	font-weight: 300;
+	margin: 5rem 0 2rem;
+}
+
+p,
+p ~ p {
+	font-size: 1em;
+	line-height: 1.5em;
+	padding-bottom: 1em;
+}
+
+.sub-h1 {
+	font-weight: 400;
+	font-size: 1.1em;
+}
+
+h2 {
+	font-weight: 300;
+	font-size: 2.25em;
+	text-transform: uppercase;
+}
+
+h3 {
+	font-weight: 300;
+	font-size: 1.75em;
+	text-transform: uppercase;
+	letter-spacing: 1px;
+	line-height: 1em;
+	padding: 1em 0 .5em;
+	color: #a60f2d;
+}
+
+h2 + h3 {
+	padding-top: .7rem;
+}
+
+h4 {
+	font-weight: 800;
+	font-size: 1.1em;
+	text-transform: uppercase;
+	line-height: 1em;
+	padding: 20px 0 10px;
+	letter-spacing: .5px;
+}
+
+h5 {
+	font-weight: 700;
+	font-size: 1.1em;
+	padding: 20px 0 5px;
+	letter-spacing: .5px;
+}
+
+h6 {
+	font-weight: 400;
+	font-size: 1em;
+	color: #a60f2d;
+	padding: 20px 0 5px;
+}
+
+a {
+	border-bottom: 1px solid #da1e00;
+	color: inherit;
+	transition: all .3s ease;
+}
+
+a,
+p a,
+li a {
+	font-weight: 400;
+}
+
+a:hover {
+	color: #da1e00;
+}
+
+ul {
+	list-style: none;
+	padding: 0 0 1.5em 2.5em;
+}
+
+ul li {
+	list-style: none;
+	position: relative;
+}
+
+ol li,
+ul li {
+	padding: 0 0 .5em;
+	font-weight: 300;
+}
+
+ul li:before {
+	content: "";
+	position: absolute;
+	left: -1.25em;
+	top: 13px;
+	background: #a31d36;
+	height: 2px;
+	width: 6px;
+}
+
+strong {
+	font-weight: 700;
+}
+
+.pageheader-sub {
+	font-weight: 700;
+	padding-bottom: 0;
+}
+
+p + ul,
+h1 + ul,
+h2 + ul,
+h3 + ul {
+	margin-top: -.5em;
+}
+
+blockquote {
+	font-size: 1.5rem;
+	font-family: "Open Sans";
+	font-style: italic;
+	font-weight: 300;
+	padding: 2rem 0 1.5rem 3rem;
+}
+
+blockquote cite {
+	letter-spacing: 1px;
+	font-size: .8rem;
+	font-style: normal;
+	font-weight: 700;
+	text-transform: uppercase;
+}
+
+cite:before {
+	content: "\2014";
+	color: #a60f2d;
+	font-size: 1.1em;
+	padding-right: .5rem;
+}
+
+::selection {
+	background: #000;
+	color: #fff;
+}
+
+p::selection {
+	background: #a60f2d;
+	color: #fff;
+}
+
+a::selection {
+	background: #da1e00;
+	color: #fff;
+}
+
+a.button,
+a.button:focus {
+	background: none;
+	border: 1px solid;
+	border-radius: 0;
+	color: #a60f2d;
+	margin-top: 1.5rem;
+	padding: .75rem 2rem;
+	text-transform: uppercase;
+	transition: all .3s ease;
+}
+
+.side-right .two a.button {
+	font-size: .8em;
+	padding: .5rem 1rem;
+}
+
+.bg-dark a.button,
+.bg-dark a.button:focus {
+	color: #fff;
+	border-color: #a60f3d;
+}
+
+a.button:hover,
+a.button:active {
+	background: #a60f3d;
+	border: 1px solid #a60f3d;
+	color: #fff;
+}

--- a/functions.php
+++ b/functions.php
@@ -8,6 +8,7 @@ include_once __DIR__ . '/includes/people-directory.php';
 include_once __DIR__ . '/includes/content-syndicate.php';
 include_once __DIR__ . '/includes/media-library.php';
 include_once __DIR__ . '/includes/breadcrumb.php';
+include_once __DIR__ . '/includes/editor.php';
 
 add_filter( 'spine_child_theme_version', 'murrow_theme_version' );
 function murrow_theme_version() {

--- a/includes/editor.php
+++ b/includes/editor.php
@@ -4,6 +4,15 @@ namespace WSU\Murrow\Editor;
 
 add_filter( 'mce_buttons', 'WSU\Murrow\Editor\add_styleselect_button' );
 add_filter( 'tiny_mce_before_init', 'WSU\Murrow\Editor\custom_style_formats' );
+add_action( 'admin_init', 'WSU\Murrow\Editor\add_editor_style', 20 );
+add_filter( 'editor_stylesheets', 'WSU\Murrow\Editor\editor_stylesheets_version' );
+
+/**
+ * Add a stylesheet to TinyMCE to help format custom content.
+ */
+function add_editor_style() {
+	\add_editor_style( 'editor/editor-style.css' );
+}
 
 /**
  * Add the "Format" button as the second option in the top row of TinyMCE.
@@ -40,4 +49,23 @@ function custom_style_formats( $settings ) {
 	$settings['style_formats'] = wp_json_encode( $style_formats );
 
 	return $settings;
+}
+
+/**
+ * Add a version number to the theme's editor stylesheets.
+ *
+ * @param array $stylesheets
+ *
+ * @return array
+ */
+function editor_stylesheets_version( $stylesheets ) {
+	foreach( $stylesheets as $k => $stylesheet ) {
+		if ( 0 !== strpos( $stylesheet, get_stylesheet_directory_uri() ) ) {
+			continue;
+		}
+
+		$stylesheets[ $k ] = $stylesheet . '?v=' . spine_get_child_version();
+	}
+
+	return $stylesheets;
 }

--- a/includes/editor.php
+++ b/includes/editor.php
@@ -59,7 +59,7 @@ function custom_style_formats( $settings ) {
  * @return array
  */
 function editor_stylesheets_version( $stylesheets ) {
-	foreach( $stylesheets as $k => $stylesheet ) {
+	foreach ( $stylesheets as $k => $stylesheet ) {
 		if ( 0 !== strpos( $stylesheet, get_stylesheet_directory_uri() ) ) {
 			continue;
 		}

--- a/includes/editor.php
+++ b/includes/editor.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace WSU\Murrow\Editor;
+
+add_filter( 'mce_buttons', 'WSU\Murrow\Editor\add_styleselect_button' );
+add_filter( 'tiny_mce_before_init', 'WSU\Murrow\Editor\custom_style_formats' );
+
+/**
+ * Add the "Format" button as the second option in the top row of TinyMCE.
+ *
+ * @param array $buttons
+ *
+ * @return array
+ */
+function add_styleselect_button( $buttons ) {
+	$button = array_shift( $buttons );
+	array_unshift( $buttons, 'styleselect' );
+	array_unshift( $buttons, $button );
+
+	return $buttons;
+}
+
+/**
+ * Add custom style formats to the "Format" drop-down in TinyMCE.
+ *
+ * @param array $settings
+ *
+ * @return array
+ */
+function custom_style_formats( $settings ) {
+
+	$style_formats = array(
+		array(
+			'title' => 'Pageheader Sub',
+			'block' => 'p',
+			'classes' => 'pageheader-sub',
+		),
+	);
+
+	$settings['style_formats'] = wp_json_encode( $style_formats );
+
+	return $settings;
+}


### PR DESCRIPTION
This adds "Pageheader Sub" to a "Formats" menu so that content editors can easily format a paragraph. It also adds an editor stylesheet so that the formatting is immediately obvious when selected.