### PR TITLE
Default inline `img` behavior class change in `side-right` to `alignnone`

### DIFF
--- a/css/01-layout.css
+++ b/css/01-layout.css
@@ -41,7 +41,7 @@ main .hentry section:first-child {
 }
 
 /* images */
-#jacket #binder main section.side-right .column.one img.alignright {
+#jacket #binder main section.side-right .column.one img.alignnone {
 	width: 100%;
 	max-width: calc((1188px - 4rem) / 2);
 	float: right;
@@ -51,7 +51,7 @@ main .hentry section:first-child {
 
 @media (max-width: 1252px) {
 
-	#jacket #binder main section.side-right .column.one img.alignright {
+	#jacket #binder main section.side-right .column.one img.alignnone {
 		max-width: calc((100vw - 8rem) / 2);
 		margin-right: calc((100vw - 8rem) / -3);
 	}

--- a/style.css
+++ b/style.css
@@ -51,7 +51,7 @@ main .hentry section:first-child {
 }
 
 /* images */
-#jacket #binder main section.side-right .column.one img.alignright {
+#jacket #binder main section.side-right .column.one img.alignnone {
 	width: 100%;
 	max-width: calc((1188px - 4rem) / 2);
 	float: right;
@@ -61,7 +61,7 @@ main .hentry section:first-child {
 
 @media (max-width: 1252px) {
 
-	#jacket #binder main section.side-right .column.one img.alignright {
+	#jacket #binder main section.side-right .column.one img.alignnone {
 		max-width: calc((100vw - 8rem) / 2);
 		margin-right: calc((100vw - 8rem) / -3);
 	}


### PR DESCRIPTION
- `.column.one` inline `img` bleed into `.column.two` in `section.side-right` now happens with class `alignnone` instead of `alignright`.