### PR TITLE
[PR] Fix PHP error in breadcrumb output

### DIFF
--- a/css/00-banner.css
+++ b/css/00-banner.css
@@ -5,5 +5,5 @@
  Author:      WSU University Communications
  Author URI:  https://web.wsu.edu
  Template:    spine
- Version:     0.6.10
+ Version:     0.6.11
 */

--- a/functions.php
+++ b/functions.php
@@ -13,7 +13,7 @@ include_once __DIR__ . '/includes/featured-stories.php';
 
 add_filter( 'spine_child_theme_version', 'murrow_theme_version' );
 function murrow_theme_version() {
-	return '0.6.10';
+	return '0.6.11';
 }
 
 // Disable background image selection for posts and pages.

--- a/includes/breadcrumb.php
+++ b/includes/breadcrumb.php
@@ -14,6 +14,10 @@ add_action( 'bcn_after_fill', 'WSU\Murrow\Breadcrumb\remove_current_item' );
  * @param \bcn_breadcrumb_trail $trail The object containing the breadcrumb trail.
  */
 function remove_current_item( $trail ) {
+	if ( ! is_object( $trail ) ) {
+		return;
+	}
+
 	$types = $trail->breadcrumbs[0]->get_types();
 
 	if ( is_array( $types ) && in_array( 'current-item', $types, true ) ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "murrow.wsu.edu",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murrow.wsu.edu",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "repository": {
     "type": "git",
     "url": "https://github.com/washingtonstateuniversity/murrow.wsu.edu"

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  Author:      WSU University Communications
  Author URI:  https://web.wsu.edu
  Template:    spine
- Version:     0.6.10
+ Version:     0.6.11
 */
 
 html {


### PR DESCRIPTION
For some reason, the passed breadcrumb trail is null on author pages.

```
PHP Fatal error:  Uncaught Error: Call to a member function get_types()
on null
/opt/rh/rh-nginx112/root/usr/share/nginx/html/wp-content/themes/murrow-theme/includes/breadcrumb.php:17
```